### PR TITLE
(FEAT) / Add Dark Mode for GitFun 🎨

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,15 +3,22 @@
 @tailwind utilities;
 
 :root {
-  --sh-class: #2d5e9d;
-  --sh-identifier: #354150;
-  --sh-sign: #8996a3;
-  --sh-property: #0550ae;
-  --sh-entity: #249a97;
-  --sh-jsxliterals: #6266d1;
-  --sh-string: #00a99a;
-  --sh-keyword: #f47067;
-  --sh-comment: #a19595;
+  --color-white: #ffffff;
+  --color-dark: #09090b;
+  --color-grey: #f4f4f5;
+}
+
+html {
+  background-color: var(--color-white);
+  color: var(--color-dark);
+}
+
+html.dark {
+  background-color: var(--color-dark);
+  color: var(--color-grey);
+  transition:
+    background-color 0.3s,
+    color 0.3s;
 }
 
 body {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,20 +1,12 @@
 import { ThemeProvider } from 'next-themes';
 import type { Metadata } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { GeistSans } from 'geist/font/sans';
+import { GeistMono } from 'geist/font/mono';
+
 import './globals.css';
 import { Toaster } from '@/components/ui/toaster';
 import { Header } from '@/components/layout/header';
 import { Footer } from '@/components/layout/footer';
-
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin'],
-});
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
-});
 
 export const metadata: Metadata = {
   title: 'GitFun - Make Commits Easy and Fun',
@@ -62,7 +54,7 @@ export default function RootLayout({
     <>
       <html lang="en">
         <body
-          className={`${geistSans.variable} ${geistMono.variable} dark:bg-bgBlack font-geist_sans text-prDark mx-auto max-w-5xl bg-bgWhite px-4 antialiased dark:text-prLight`}
+          className={`${GeistSans.variable} ${GeistMono.variable} dark:bg-bgBlack font-geist_sans text-prDark mx-auto max-w-5xl bg-bgWhite px-4 antialiased dark:text-prLight`}
         >
           <ThemeProvider
             attribute="class"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -60,12 +60,16 @@ export default function RootLayout({
 }>) {
   return (
     <>
-      <html
-        lang="en"
-        className={`${geistSans.variable} ${geistMono.variable} dark:bg-bgBlack font-geist_sans text-prDark mx-auto max-w-5xl bg-bgWhite px-4 antialiased dark:text-prLight`}
-      >
-        <body>
-          <ThemeProvider attribute="class">
+      <html lang="en">
+        <body
+          className={`${geistSans.variable} ${geistMono.variable} dark:bg-bgBlack font-geist_sans text-prDark mx-auto max-w-5xl bg-bgWhite px-4 antialiased dark:text-prLight`}
+        >
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="light"
+            enableSystem={true}
+            disableTransitionOnChange
+          >
             <Header />
             <main>{children}</main>
             <Footer />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import { ThemeProvider } from 'next-themes';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
@@ -20,11 +21,11 @@ export const metadata: Metadata = {
   description:
     'GitFun simplifies your commit messages with emoji guides and best practices for Git.',
   keywords: [
-    'Git',
+    'git',
     'commit messages',
     'emoji guide',
-    'Git best practices',
-    'Git tools',
+    'git best practices',
+    'git tools',
   ],
   authors: [{ name: 'Alpha Diop', url: '' }],
   openGraph: {
@@ -58,15 +59,20 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} mx-auto max-w-5xl bg-white px-4 font-geist_sans text-zinc-950 antialiased`}
+    <>
+      <html
+        lang="en"
+        className={`${geistSans.variable} ${geistMono.variable} dark:bg-bgBlack font-geist_sans text-prDark mx-auto max-w-5xl bg-bgWhite px-4 antialiased dark:text-prLight`}
       >
-        <Header />
-        <main>{children}</main>
-        <Footer />
-        <Toaster />
-      </body>
-    </html>
+        <body>
+          <ThemeProvider attribute="class">
+            <Header />
+            <main>{children}</main>
+            <Footer />
+            <Toaster />
+          </ThemeProvider>
+        </body>
+      </html>
+    </>
   );
 }

--- a/components/emoji-card.tsx
+++ b/components/emoji-card.tsx
@@ -42,7 +42,7 @@ export function EmojiCard({ emoji }: EmojiCardProps) {
         <CardDescription>{emoji.usage}</CardDescription>
       </CardHeader>
       <CardContent>
-        <pre className="block w-full overflow-x-auto rounded-md bg-zinc-100 p-2 font-geist_mono text-sm">
+        <pre className="font-geist_mono dark:bg-prDark block w-full overflow-x-auto rounded-md bg-prLight p-2 text-sm">
           <code
             dangerouslySetInnerHTML={{ __html: highlight(emoji.example) }}
           />

--- a/components/emoji-guide.tsx
+++ b/components/emoji-guide.tsx
@@ -21,8 +21,10 @@ export function EmojiGuide() {
   return (
     <section className="space-y-6 py-8">
       <div className="space-y-2">
-        <h1 className="text-3xl font-bold">Commit Message Emoji Guide</h1>
-        <p className="text-zinc-800">
+        <h1 className="text-prDark text-3xl font-bold dark:text-prLight">
+          Commit Message Emoji Guide
+        </h1>
+        <p className="text-prGrey dark:text-prGrey">
           Choose the perfect emoji for your commits
         </p>
       </div>

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -2,10 +2,10 @@ import Link from 'next/link';
 
 export function Footer() {
   return (
-    <footer className="border-t py-6 md:py-0">
+    <footer className="dark:border-prDark border-t border-prLight py-6 md:py-0">
       <div className="container flex flex-col items-center justify-between gap-4 md:h-24 md:flex-row">
         <div className="flex flex-col items-center gap-4 px-8 md:flex-row md:gap-2 md:px-0">
-          <p className="text-muted-foreground text-center text-sm leading-loose md:text-left">
+          <p className="text-prDark text-center text-sm leading-loose dark:text-prLight md:text-left">
             Built by{' '}
             <Link
               href="https://github.com/alphajoop"

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -4,7 +4,7 @@ import { ThemeToggle } from '@/components/theme-toggle';
 
 export function Header() {
   return (
-    <header className="bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 w-full border-b backdrop-blur">
+    <header className="bg-background/95 supports-[backdrop-filter]:bg-background/60 dark:border-prDark sticky top-0 z-50 w-full border-b border-prLight backdrop-blur">
       <div className="container flex h-14 items-center gap-4">
         <div className="flex">
           <Link href="/" className="mr-6 flex items-center space-x-2">
@@ -15,13 +15,13 @@ export function Header() {
           <nav className="flex items-center space-x-6">
             <Link
               href="/docs"
-              className="hover:text-foreground/80 text-sm font-medium transition-colors"
+              className="text-sm font-medium transition-colors hover:text-prGrey"
             >
               Docs
             </Link>
             <Link
               href="/examples"
-              className="hover:text-foreground/80 text-sm font-medium transition-colors"
+              className="text-sm font-medium transition-colors hover:text-prGrey"
             >
               Examples
             </Link>

--- a/components/layout/test.tsx
+++ b/components/layout/test.tsx
@@ -1,0 +1,7 @@
+const Test = () => {
+  return (
+    <div className="text-prDark underline-offset-4 hover:underline dark:text-prLight"></div>
+  );
+};
+
+export default Test;

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,21 +5,21 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 dark:ring-offset-zinc-950 dark:focus-visible:ring-zinc-300',
+  'focus-visible:ring-prDark dark:ring-offset-prDark inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-bgWhite transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:focus-visible:ring-prLight [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
         default:
-          'bg-zinc-900 text-zinc-50 hover:bg-zinc-900/90 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-50/90',
+          'bg-bgBlack hover:bg-prDark dark:text-prDark text-prLight dark:bg-bgWhite dark:hover:bg-prLight',
         destructive:
-          'bg-red-500 text-zinc-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-zinc-50 dark:hover:bg-red-900/90',
+          'bg-red-500 text-prLight hover:bg-red-500/90 dark:bg-red-900 dark:text-prLight dark:hover:bg-red-900/90',
         outline:
-          'border border-zinc-200 bg-white hover:bg-zinc-100 hover:text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:hover:bg-zinc-800 dark:hover:text-zinc-50',
+          'hover:text-prDark dark:border-prDark dark:bg-bgBlack dark:hover:bg-prDark border border-prLight bg-bgWhite hover:bg-prLight dark:hover:text-prLight',
         secondary:
-          'bg-zinc-100 text-zinc-900 hover:bg-zinc-100/80 dark:bg-zinc-800 dark:text-zinc-50 dark:hover:bg-zinc-800/80',
+          'text-prDark dark:bg-bgBlack dark:hover:bg-prDark bg-bgWhite hover:bg-prLight dark:text-prLight',
         ghost:
-          'hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-50',
-        link: 'text-zinc-900 underline-offset-4 hover:underline dark:text-zinc-50',
+          'hover:text-prDark dark:hover:bg-bgBlack hover:bg-bgWhite dark:hover:text-prLight',
+        link: 'text-prDark underline-offset-4 hover:underline dark:text-prLight',
       },
       size: {
         default: 'h-10 px-4 py-2',

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 import { cn } from '@/lib/utils';
 
 const Card = React.forwardRef<
@@ -9,7 +8,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'rounded-lg border border-zinc-200 bg-white text-zinc-950 shadow-sm dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50',
+      'dark:bg-bgBlack text-prDark dark:border-prDark rounded-lg border border-prLight bg-bgWhite shadow-sm dark:text-prLight',
       className,
     )}
     {...props}
@@ -50,7 +49,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('text-sm text-zinc-500 dark:text-zinc-400', className)}
+    className={cn('text-sm text-prGrey dark:text-prGrey', className)}
     {...props}
   />
 ));

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -15,7 +15,7 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      'flex h-full w-full flex-col overflow-hidden rounded-md bg-white text-zinc-950 dark:bg-zinc-950 dark:text-zinc-50',
+      'dark:bg-bgBlack text-prDark flex h-full w-full flex-col overflow-hidden rounded-md bg-bgWhite dark:text-prLight',
       className,
     )}
     {...props}
@@ -27,7 +27,7 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-zinc-500 dark:[&_[cmdk-group-heading]]:text-zinc-400 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-prGrey dark:[&_[cmdk-group-heading]]:text-prGrey [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>
       </DialogContent>
@@ -44,7 +44,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        'flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-zinc-500 disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-zinc-400',
+        'flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-prGrey disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-prGrey',
         className,
       )}
       {...props}
@@ -87,7 +87,7 @@ const CommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      'overflow-hidden p-1 text-zinc-950 dark:text-zinc-50 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-zinc-500 dark:[&_[cmdk-group-heading]]:text-zinc-400',
+      'text-prDark overflow-hidden p-1 dark:text-prLight [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-prGrey dark:[&_[cmdk-group-heading]]:text-prGrey',
       className,
     )}
     {...props}
@@ -102,7 +102,7 @@ const CommandSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Separator
     ref={ref}
-    className={cn('-mx-1 h-px bg-zinc-200 dark:bg-zinc-800', className)}
+    className={cn('dark:bg-bgBlack -mx-1 h-px bg-bgWhite', className)}
     {...props}
   />
 ));
@@ -115,7 +115,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-zinc-100 data-[selected=true]:text-zinc-900 data-[disabled=true]:opacity-50 dark:data-[selected='true']:bg-zinc-800 dark:data-[selected=true]:text-zinc-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "dark:data-[selected='true']:bg-bgBlack data-[selected=true]:text-prDark relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-bgWhite data-[disabled=true]:opacity-50 dark:data-[selected=true]:text-prLight [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className,
     )}
     {...props}
@@ -131,7 +131,7 @@ const CommandShortcut = ({
   return (
     <span
       className={cn(
-        'ml-auto text-xs tracking-widest text-zinc-500 dark:text-zinc-400',
+        'ml-auto text-xs tracking-widest text-prGrey dark:text-prLight',
         className,
       )}
       {...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'bg-bgBlack fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -38,13 +38,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-zinc-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] dark:border-zinc-800 dark:bg-zinc-950 sm:rounded-lg',
+        'dark:border-prDark dark:bg-bgBlack fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-prLight bg-bgWhite p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-zinc-950 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-zinc-100 data-[state=open]:text-zinc-500 dark:ring-offset-zinc-950 dark:focus:ring-zinc-300 dark:data-[state=open]:bg-zinc-800 dark:data-[state=open]:text-zinc-400">
+      <DialogPrimitive.Close className="focus:ring-prDark dark:ring-offset-prDark dark:data-[state=open]:bg-bgBlack absolute right-4 top-4 rounded-sm opacity-70 ring-offset-prLight transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-bgWhite data-[state=open]:text-prGrey dark:focus:ring-prLight dark:data-[state=open]:text-prGrey">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
@@ -102,7 +102,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn('text-sm text-zinc-500 dark:text-zinc-400', className)}
+    className={cn('text-sm text-prGrey dark:text-prLight', className)}
     {...props}
   />
 ));

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-zinc-200 bg-white px-3 py-2 text-base ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-zinc-950 placeholder:text-zinc-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:bg-zinc-950 dark:ring-offset-zinc-950 dark:file:text-zinc-50 dark:placeholder:text-zinc-400 dark:focus-visible:ring-zinc-300 md:text-sm',
+          'dark:bg-bgBlack file:text-prDark dark:border-prDark dark:ring-offset-prDark dark:focus-visible:ring-prDark flex h-10 w-full rounded-md border border-prLight bg-bgWhite px-3 py-2 text-base ring-offset-bgWhite file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-prGrey focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-prGrey focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:file:text-prLight dark:placeholder:text-prGrey md:text-sm',
           className,
         )}
         ref={ref}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-72 rounded-md border border-zinc-200 bg-white p-4 text-zinc-950 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50',
+        'text-prDark dark:border-prDark dark:bg-bgBlack z-50 w-72 rounded-md border border-prLight bg-bgWhite p-4 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:text-prLight',
         className,
       )}
       {...props}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-950 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:bg-zinc-950 dark:ring-offset-zinc-950 dark:placeholder:text-zinc-400 dark:focus:ring-zinc-300 [&>span]:line-clamp-1',
+      'focus:ring-prDark dark:border-prDark dark:bg-bgBlack dark:ring-offset-prDark flex h-10 w-full items-center justify-between rounded-md border border-prLight bg-bgWhite px-3 py-2 text-sm ring-offset-prLight placeholder:text-prGrey focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:placeholder:text-prGrey dark:focus:ring-prLight [&>span]:line-clamp-1',
       className,
     )}
     {...props}
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-zinc-200 bg-white text-zinc-950 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50',
+        'text-prDark dark:border-prDark dark:bg-bgBlack relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-prLight bg-bgWhite shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:text-prLight',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className,
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-zinc-100 focus:text-zinc-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-zinc-800 dark:focus:text-zinc-50',
+      'focus:bg-bgBlack focus:text-prDark dark:focus:bg-bgBlack relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:text-prLight',
       className,
     )}
     {...props}
@@ -140,7 +140,7 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-zinc-100 dark:bg-zinc-800', className)}
+    className={cn('dark:bg-bgBlack -mx-1 my-1 h-px bg-bgWhite', className)}
     {...props}
   />
 ));

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -14,7 +14,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex h-10 items-center justify-center rounded-md bg-zinc-100 p-1 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400',
+      'text-prDark dark:bg-prDark inline-flex h-10 items-center justify-center rounded-md bg-prLight p-1 dark:text-prLight',
       className,
     )}
     {...props}
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white data-[state=active]:text-zinc-950 data-[state=active]:shadow-sm dark:ring-offset-zinc-950 dark:focus-visible:ring-zinc-300 dark:data-[state=active]:bg-zinc-950 dark:data-[state=active]:text-zinc-50',
+      'dark:data-[state=active]:bg-bgBlack focus-visible:ring-prDark data-[state=active]:text-prDark dark:ring-offset-prDark inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-bgWhite transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-bgWhite data-[state=active]:shadow-sm dark:focus-visible:ring-prLight dark:data-[state=active]:text-prLight',
       className,
     )}
     {...props}
@@ -44,7 +44,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      'mt-2 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-950 focus-visible:ring-offset-2 dark:ring-offset-zinc-950 dark:focus-visible:ring-zinc-300',
+      'dark:ring-offset-bgBlack focus-visible:ring-prDark mt-2 ring-offset-bgWhite focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 dark:focus-visible:ring-prLight',
       className,
     )}
     {...props}

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -25,14 +25,14 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
-  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border border-zinc-200 p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full dark:border-zinc-800',
+  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border border-prLight p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full dark:border-prDark',
   {
     variants: {
       variant: {
         default:
-          'border bg-white text-zinc-950 dark:bg-zinc-950 dark:text-zinc-50',
+          'border bg-bgWhite text-prDark dark:bg-bgBlack dark:text-prLight',
         destructive:
-          'destructive group border-red-500 bg-red-500 text-zinc-50 dark:border-red-900 dark:bg-red-900 dark:text-zinc-50',
+          'destructive group border-red-500 bg-red-500 text-prGrey dark:border-red-900 dark:bg-red-900 dark:text-prGrey',
       },
     },
     defaultVariants: {
@@ -63,7 +63,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-zinc-200 bg-transparent px-3 text-sm font-medium ring-offset-white transition-colors hover:bg-zinc-100 focus:outline-none focus:ring-2 focus:ring-zinc-950 focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-zinc-100/40 group-[.destructive]:hover:border-red-500/30 group-[.destructive]:hover:bg-red-500 group-[.destructive]:hover:text-zinc-50 group-[.destructive]:focus:ring-red-500 dark:border-zinc-800 dark:ring-offset-zinc-950 dark:hover:bg-zinc-800 dark:focus:ring-zinc-300 dark:group-[.destructive]:border-zinc-800/40 dark:group-[.destructive]:hover:border-red-900/30 dark:group-[.destructive]:hover:bg-red-900 dark:group-[.destructive]:hover:text-zinc-50 dark:group-[.destructive]:focus:ring-red-900',
+      'focus:ring-prDark dark:border-prDark dark:ring-offset-prDark dark:group-[.destructive]:border-prDark inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-prLight bg-transparent px-3 text-sm font-medium ring-offset-prLight transition-colors hover:bg-prGrey focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-prGrey group-[.destructive]:hover:border-red-500/30 group-[.destructive]:hover:bg-red-500 group-[.destructive]:hover:text-prLight group-[.destructive]:focus:ring-red-500 dark:hover:bg-prGrey dark:focus:ring-prLight dark:group-[.destructive]:hover:border-red-900/30 dark:group-[.destructive]:hover:bg-red-900 dark:group-[.destructive]:hover:text-prLight dark:group-[.destructive]:focus:ring-red-900',
       className,
     )}
     {...props}
@@ -78,7 +78,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      'absolute right-2 top-2 rounded-md p-1 text-zinc-950/50 opacity-0 transition-opacity hover:text-zinc-950 focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600 dark:text-zinc-50/50 dark:hover:text-zinc-50',
+      'text-prDark absolute right-2 top-2 rounded-md p-1 opacity-0 transition-opacity hover:text-prGrey focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600 dark:text-prLight dark:hover:text-prGrey',
       className,
     )}
     toast-close=""

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.0",
+    "geist": "^1.3.1",
     "lucide-react": "^0.469.0",
     "next": "15.1.3",
     "next-themes": "^0.4.4",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from 'tailwindcss';
 
 export default {
-  darkMode: 'class',
+  darkMode: ['class'],
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from 'tailwindcss';
 
 export default {
-  darkMode: ['class'],
+  darkMode: 'class',
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -14,8 +14,13 @@ export default {
     },
     extend: {
       colors: {
-        background: 'var(--background)',
-        foreground: 'var(--foreground)',
+        // background color
+        bgWhite: '#ffffff',
+        bgBlack: '#09090b',
+        // primitive color
+        prGrey: '#828291',
+        prLight: '#f4f4f5',
+        prDark: '#1c1c1f',
       },
       borderRadius: {
         lg: 'var(--radius)',
@@ -24,6 +29,5 @@ export default {
       },
     },
   },
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   plugins: [require('tailwindcss-animate')],
 } satisfies Config;


### PR DESCRIPTION
# **PR Description**
This PR introduces **Dark Mode** to GitFun, enhancing user experience for those who prefer a low-light interface. The feature is fully responsive and switches seamlessly between light and dark themes, providing better usability and aesthetic appeal.

---

## **Key Changes**
1. **Added Dark Mode Support** :
   - Implemented dark theme styles using Tailwind CSS and dynamic class handling.
   - Ensured consistency across all components for both light and dark themes.

2. **New Color Palette**:
   - Added the following colors to support the dark mode:
     - **Background Colors**:
       - `bgWhite`: `#ffffff` (Light theme background).
       - `bgBlack`: `#09090b` (Dark theme background).
     - **Primitive Colors**:
       - `prGrey`: `#828291` (Neutral elements like borders and muted text).
       - `prLight`: `#f4f4f5` (Light theme primary color).
       - `prDark`: `#1c1c1f` (Dark theme primary color).

3. **Theme Switching**:
   - Integrated `next-themes` for dynamic theme switching with class-based toggling.
   - Default theme set to "light," with user preference remembered across sessions.

4. **Updated Layout and Components**:
   - Ensured components like the header, footer, and buttons adapt dynamically to the active theme.

